### PR TITLE
Add gh CLI version check

### DIFF
--- a/src/ac-mrc.js
+++ b/src/ac-mrc.js
@@ -78,6 +78,14 @@ program
     const tasks = new Listr(
       [
         {
+          title: 'Checking prerequisities',
+          task: async (ctx, task) => {
+            const ghCheck = await helpers.view.warnAboutGHVersion();
+
+            return ghCheck;
+          },
+        },
+        {
           title: 'Getting the repo list',
           task: async (ctx, task) => {
             ctx.repos = [];

--- a/src/helpers/view.js
+++ b/src/helpers/view.js
@@ -3,6 +3,7 @@ import boxen from 'boxen';
 import { white, red, yellow } from 'kleur';
 import updater from 'update-notifier';
 import notifier from 'node-notifier';
+import execa from 'execa';
 import helpers from './index';
 
 // Info box options
@@ -68,6 +69,22 @@ module.exports = {
 
   warn(message) {
     this.log(`${yellow('WARNING:')} ${message}`);
+  },
+
+  async warnAboutGHVersion() {
+    const MIN_GH_VERSION = '1.1.0';
+    return new Promise(async (resolve, reject) => {
+      const { stdout } = await execa('gh', ['--version']);
+
+      const output = stdout.split(' ');
+      const version = output?.[2] || 0;
+
+      if (semver.satisfies(version, `>=${MIN_GH_VERSION}`) === false) {
+        reject(new Error(`Please upgrade your GitHub CLI to ${MIN_GH_VERSION}. Yours ${version}`));
+      } else {
+        resolve(true);
+      }
+    });
   },
 
   warnAboutNodeVersion() {


### PR DESCRIPTION
To be able to use some features of the app, we need to specify a minimum version number for `gh` CLI. To check the version of the `gh` CLI version, I've added a `prerequisite` step.