### PR TITLE
Remove --base-dir flag from gh command till new gh version

### DIFF
--- a/src/ac-mrc.js
+++ b/src/ac-mrc.js
@@ -23,7 +23,7 @@ const githubCreate = ({ name, type, target }) => {
         'create',
         `--${type || 'public'}`,
         '--confirm',
-        `--init-base-dir=${target}`, // https://github.com/cli/cli/pull/2098
+        //`--init-base-dir=${target}`, // https://github.com/cli/cli/pull/2098
         name,
       ])
         .then((res) => resolve(res))
@@ -153,7 +153,6 @@ program
         {
           title: 'Bulk creation',
           task: (ctx) => {
-            console.log('repos', ctx.repos);
             const repoTasks = ctx.repos.map((repo) => ({
               title: repo?.name,
               task: (ctx) => {
@@ -161,15 +160,15 @@ program
                   {
                     title: 'Create and initialize',
                     task: (ctx, task) => {
-                      let processStepError;
+                      ctx.processStepError = '';
 
                       return githubCreate({ ...repo, target: ctx.targetDir })
                         .then(() => {
                           const split = repo?.name.split('/');
                           const repoName = split[1] ? split[1] : repo?.name;
-                          // task.title = `Copy existing files from source`;
-
                           const targetWithRepo = `${ctx.targetDir}/${repoName}`;
+
+                          // task.title = `Copy existing files from source`;
 
                           if (!program.noPush) {
                             return helpers.assets
@@ -179,12 +178,12 @@ program
                               )
                               .then(() => {
                                 task.title = `Stage files for the initial commits`;
-                                processStepError = 'Stage process failed';
+                                ctx.processStepError = 'Stage process failed';
                                 return execa('git', ['-C', targetWithRepo, 'add', '.']);
                               })
                               .then(() => {
                                 task.title = `Commit the staged files`;
-                                processStepError = 'Staged files couldnt commit';
+                                ctx.processStepError = 'Staged files couldnt commit';
                                 return execa('git', [
                                   '-C',
                                   targetWithRepo,
@@ -195,7 +194,7 @@ program
                               })
                               .then(() => {
                                 task.title = `Push the changes`;
-                                processStepError = 'Commited changes couldnt push';
+                                ctx.processStepError = 'Commited changes couldnt push';
                                 return execa('git', [
                                   '-C',
                                   targetWithRepo,


### PR DESCRIPTION
The current version of `gh` still doesn't have `--base-dir` flag to specify the base init dir for the newly created repo. There is a pull request I sent (https://github.com/cli/cli/pull/2098) and it's currently in review.

Until it's merged, I've disabled the base init dir flag.